### PR TITLE
Add license tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ setuptools.setup(
     version="0.0.16",
     author="Magnus Eldén",
     description="Core types for peaqev car charging",
+    license="MIT",
     packages=["peaqevcore"],
     install_requires=['pytest', 'datetime', 'statistics'],
 )   


### PR DESCRIPTION
Allow third-party tools (e. g., PyPI or `pyp2rpm`) to get the license details in a simple way.