### PR TITLE
Move pytest to tests_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,5 +8,5 @@ setuptools.setup(
     url="https://github.com/elden1337/peaqev-core",
     license="MIT",
     packages=["peaqevcore"],
-    install_requires=['pytest']
+    test_requires=['pytest']
 )   


### PR DESCRIPTION
`pytest` is not a run-time requirement but needed for running the test suite.